### PR TITLE
Add support for SSH git@ URLs in determine_project function

### DIFF
--- a/gitlab_trace.py
+++ b/gitlab_trace.py
@@ -46,6 +46,24 @@ def pipe(command: List[str]) -> str:
 def determine_project(url: Optional[str] = None) -> Optional[str]:
     if not url:
         url = pipe('git remote get-url origin'.split())
+
+    # Handle git@ SSH URLs (e.g., git@gitlab.com:owner/project.git)
+    if url.startswith('git@'):
+        # Parse git@ format: git@hostname:path
+        try:
+            if ':' in url:
+                # Remove 'git@' prefix
+                host_part, path_part = url[4:].split(':', 1)
+                if host_part == 'github.com':
+                    return None
+                project = path_part.strip('/')
+                if project.endswith('.git'):
+                    project = project[:-len('.git')]
+                return project
+        except ValueError:
+            return None
+
+    # Handle URLs with protocol (http://, https://, ssh://)
     if '://' not in url:
         return None
     if urllib.parse.urlparse(url).hostname in ('', 'github.com'):

--- a/tests.py
+++ b/tests.py
@@ -144,6 +144,10 @@ def test_pipe():
     ('https://gitlab.com/owner/project.git', 'owner/project'),
     ('https://gitlab.com:443/owner/project.git', 'owner/project'),
     ('ssh://git@gitlab.example.com:23/owner/project.git', 'owner/project'),
+    ('git@gitlab.com:owner/project.git', 'owner/project'),
+    ('git@gitlab.example.com:group/subgroup/project.git', 'group/subgroup/project'),
+    ('git@my-gitlab.company.com:owner/project', 'owner/project'),
+    ('git@github.com:owner/project.git', None),
     ('https://github.com/owner/project', None),
     ('fridge:git/random.git', None),
 ])


### PR DESCRIPTION
Addresses https://github.com/mgedmin/gitlab-trace/issues/4

- Parse git@hostname:path format for SSH URLs
- Add proper handling for git@ URLs in determine_project()
- Exclude GitHub SSH URLs (return None as expected)
- Add comprehensive test cases for git@ URL formats